### PR TITLE
allow other types for query arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ func main() {
 		panic(err)
 	}
 
-	e, err := c.Execute("SELECT * FROM users WHERE id=?", "1");
+	e, err := c.Execute("SELECT * FROM users WHERE id=?", 1);
 	if err != nil {
 		panic(err)
 	}
@@ -72,7 +72,7 @@ planetscale.NewConnection(&planetscale.Config{
 ## Executing
 Executing performs a query to a PlanetScale Database.
 ```go
-connection.Execute("SELECT * FROM users WHERE id=?", "1")
+connection.Execute("SELECT * FROM users WHERE id=?", 1)
 ```
 
 ### Selects

--- a/execute.go
+++ b/execute.go
@@ -63,7 +63,7 @@ type Executed struct {
 	rows   []*resultRow
 }
 
-func (c *Connection) Execute(query string, args ...string) (*Executed, error) {
+func (c *Connection) Execute(query string, args ...any) (*Executed, error) {
 	q, err := sanitize(query, args)
 	if err != nil {
 		return nil, err

--- a/sanitize.go
+++ b/sanitize.go
@@ -1,16 +1,76 @@
 package planetscale
 
 import (
+	"encoding/hex"
 	"errors"
+	"strconv"
 	"strings"
+	"time"
 )
 
-func sanitize(query string, args []string) (string, error) {
+func sanitize(query string, args []any) (string, error) {
 	if strings.Count(query, "?") != len(args) {
 		return "", errors.New("invalid amount of query args")
 	}
 
-	// escape important values
+	var f strings.Builder
+	i := 0
+
+	for _, c := range query {
+		if c != '?' {
+			f.WriteRune(c)
+			continue
+		}
+
+		if err := sanitizeArg(args[i], &f); err != nil {
+			return "", err
+		}
+
+		i++
+	}
+
+	return f.String(), nil
+}
+
+func sanitizeArg(arg any, f *strings.Builder) error {
+	switch a := arg.(type) {
+	case nil:
+		f.WriteString("null")
+	case bool:
+		f.WriteString(strconv.FormatBool(a))
+	case string:
+		f.WriteRune('\'')
+		f.WriteString(escapeString(a))
+		f.WriteRune('\'')
+	case int:
+		f.WriteString(strconv.FormatInt(int64(a), 10))
+	case int8:
+		f.WriteString(strconv.FormatInt(int64(a), 10))
+	case int16:
+		f.WriteString(strconv.FormatInt(int64(a), 10))
+	case int32:
+		f.WriteString(strconv.FormatInt(int64(a), 10))
+	case int64:
+		f.WriteString(strconv.FormatInt(a, 10))
+	case float32:
+		f.WriteString(strconv.FormatFloat(float64(a), 'f', -1, 32))
+	case float64:
+		f.WriteString(strconv.FormatFloat(a, 'f', -1, 64))
+	case time.Time:
+		f.WriteString(a.UTC().Format("2006-01-02T15:04:05.999Z07:00"))
+	case []byte:
+		f.WriteString(`'\x`)
+		f.WriteString(hex.EncodeToString(a))
+		f.WriteRune('\'')
+	default:
+		return errors.New("invalid type passed to query args")
+	}
+
+	return nil
+}
+
+func escapeString(input string) string {
+	// escapes important values
 	r := strings.NewReplacer(
 		"\"", "\\\"",
 		"'", "\\'",
@@ -23,21 +83,5 @@ func sanitize(query string, args []string) (string, error) {
 		"\x1a", "\\Z",
 	)
 
-	var f strings.Builder
-	i := 0
-
-	for _, c := range query {
-		if c != '?' {
-			f.WriteRune(c)
-			continue
-		}
-
-		f.WriteRune('\'')
-		f.WriteString(r.Replace(args[i]))
-		f.WriteRune('\'')
-
-		i++
-	}
-
-	return f.String(), nil
+	return r.Replace(input)
 }

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -5,30 +5,37 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSanitize(t *testing.T) {
 	query := "SELECT * FROM test WHERE id=?"
-	args := map[string]string{
-		"\"":   "\\\"",
-		"'":    "\\'",
-		"\n":   "\\n",
-		"\r":   "\\r",
-		"\t":   "\\t",
-		"\\":   "\\\\",
-		"\x00": "\\0",
-		"\b":   "\\b",
-		"\x1a": "\\Z",
+	args := map[any]string{
+		nil:         "null",
+		true:        "true",
+		1:           "1",
+		1.1:         "1.1",
+		time.Time{}: time.Time{}.Format("2006-01-02T15:04:05.999Z07:00"),
+
+		"\"":   "'\\\"'",
+		"'":    "'\\''",
+		"\n":   "'\\n'",
+		"\r":   "'\\r'",
+		"\t":   "'\\t'",
+		"\\":   "'\\\\'",
+		"\x00": "'\\0'",
+		"\b":   "'\\b'",
+		"\x1a": "'\\Z'",
 	}
 
 	for k, v := range args {
 		t.Run(fmt.Sprintf("sanitize %s", k), func(t *testing.T) {
-			sanitized, err := sanitize(query, []string{k})
+			sanitized, err := sanitize(query, []any{k})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			want := fmt.Sprintf("SELECT * FROM test WHERE id='%s'", v)
+			want := fmt.Sprintf("SELECT * FROM test WHERE id=%v", v)
 
 			if !strings.EqualFold(sanitized, want) {
 				t.Fatalf("wanted %s, but got %s", want, sanitized)
@@ -38,7 +45,7 @@ func TestSanitize(t *testing.T) {
 
 	t.Run("arg length", func(t *testing.T) {
 		e := errors.New("invalid amount of query args")
-		_, err := sanitize(query, []string{"", ""})
+		_, err := sanitize(query, []any{"", ""})
 
 		if err.Error() != e.Error() {
 			t.Fatalf("wanted %s, but got %s", e, err)


### PR DESCRIPTION
Allows other types then strings for query arguments.

**Old**
```go
connection.Execute("SELECT * FROM users WHERE id=?", "1")
```

**New**
```go
connection.Execute("SELECT * FROM users WHERE id=?", 1)
```